### PR TITLE
sdl2: look for libGL.so.1 in the correct directory

### DIFF
--- a/platform/sdl2/platform.in
+++ b/platform/sdl2/platform.in
@@ -9,11 +9,16 @@ add_pkgconfig(SDL2_image)
 add_pkgconfig(SDL2_ttf)
 add_pkgconfig(gio-2.0)
 
+LIBDIR = $(shell systemd-path system-library-arch)
+ifeq ($(LIBDIR),)
+LIBDIR = /usr/lib
+endif
+
 # OpenGL library
 ifeq ($(shell uname),Darwin)
 LIBS += -framework OpenGL
 else
-ifneq ($(wildcard /usr/lib/libGL.so.1),)
+ifneq ($(wildcard $(LIBDIR)/libGL.so.1),)
 add_pkgconfig(gl)
 else
 add_pkgconfig(glesv2)


### PR DESCRIPTION
It's /usr/lib64 on some Linux distros and architecture combinations (or even
/usr/lib/arch-id, according to file-hierarchy(7)).

7d6c7efdabcf970d9b59b85ac3e4f545450fcd1f